### PR TITLE
feat: add parsers for popular tx viewer links

### DIFF
--- a/src/features/txTrace/lib/links.spec.ts
+++ b/src/features/txTrace/lib/links.spec.ts
@@ -1,0 +1,164 @@
+import {extractTxInfoFromLink, type ExtractionResult} from "@features/txTrace/lib/links.ts"
+
+describe("should parse links", () => {
+  it("should parse ton.cx link", () => {
+    const res = extractTxInfoFromLink(
+      "https://ton.cx/tx/56166043000001:T6Y6ZoW71mrznFA0RyU/xV5ILpz9WUPJ9i9/4xPq1Is=:EQCqKZrrce8Ss6SZaLI-OkH2w8-xtPP9_ZvyyIZLhy9Hmpf8",
+    )
+    checkTripleResult(res, {
+      testnet: false,
+      lt: 56166043000001n,
+      hash: "T6Y6ZoW71mrznFA0RyU/xV5ILpz9WUPJ9i9/4xPq1Is=",
+      address: "EQCqKZrrce8Ss6SZaLI-OkH2w8-xtPP9_ZvyyIZLhy9Hmpf8",
+    })
+  })
+
+  it("should parse testnet ton.cx link", () => {
+    const res = extractTxInfoFromLink(
+      "https://testnet.ton.cx/tx/34542319000001:BBKTzwCTnY3xK6299queIJHIEhlB27FwxUNZVAO1uXs=:EQAkEiMt8S8Ur-umCyUn6YPXxpTzlSHH3T1vglKIFvuNObcl",
+    )
+    checkTripleResult(res, {
+      testnet: true,
+      lt: 34542319000001n,
+      hash: "BBKTzwCTnY3xK6299queIJHIEhlB27FwxUNZVAO1uXs=",
+      address: "EQAkEiMt8S8Ur-umCyUn6YPXxpTzlSHH3T1vglKIFvuNObcl",
+    })
+  })
+
+  it("shouldn't parse incorrect ton.cx links", () => {
+    expect(() =>
+      extractTxInfoFromLink(
+        "https://ton.cx/tx/56166043000001:T6Y6ZoW71mrznFA0RyU/xV5ILpz9WUPJ9i9/4xPq1Is=:EQCqKZrrce8Ss6SZaLI-OkH2w8-xtPP9_ZvyyIZLhy9Hm8",
+      ),
+    ).toThrow("Unknown address type: EQCqKZrrce8Ss6SZaLI-OkH2w8-xtPP9_ZvyyIZLhy9Hm8")
+  })
+
+  it("should parse tonviewer.com link", () => {
+    const res = extractTxInfoFromLink(
+      "https://tonviewer.com/transaction/7a236ab8bdec69ae46c02a5142dfe0dc45bf03b30607c5f88fdf86daeb8e393b",
+    )
+    checkHashResult(res, {
+      testnet: false,
+      hash: "7a236ab8bdec69ae46c02a5142dfe0dc45bf03b30607c5f88fdf86daeb8e393b",
+    })
+  })
+
+  it("should parse testnet tonviewer.com link", () => {
+    const res = extractTxInfoFromLink(
+      "https://testnet.tonviewer.com/transaction/041293cf00939d8df12badbdf6ab9e2091c8121941dbb170c543595403b5b97b",
+    )
+    checkHashResult(res, {
+      testnet: true,
+      hash: "041293cf00939d8df12badbdf6ab9e2091c8121941dbb170c543595403b5b97b",
+    })
+  })
+
+  it("should parse tonscan.org link", () => {
+    const res = extractTxInfoFromLink(
+      "https://tonscan.org/tx/7a236ab8bdec69ae46c02a5142dfe0dc45bf03b30607c5f88fdf86daeb8e393b",
+    )
+    checkHashResult(res, {
+      testnet: false,
+      hash: "7a236ab8bdec69ae46c02a5142dfe0dc45bf03b30607c5f88fdf86daeb8e393b",
+    })
+  })
+
+  it("should parse testnet tonscan.org link", () => {
+    const res = extractTxInfoFromLink(
+      "https://testnet.tonscan.org/tx/041293cf00939d8df12badbdf6ab9e2091c8121941dbb170c543595403b5b97b",
+    )
+    checkHashResult(res, {
+      testnet: true,
+      hash: "041293cf00939d8df12badbdf6ab9e2091c8121941dbb170c543595403b5b97b",
+    })
+  })
+
+  it("should parse explorer.toncoin.org link", () => {
+    const res = extractTxInfoFromLink(
+      "https://explorer.toncoin.org/transaction?account=EQCVervJ0JDFlSdOsPos17zHdRBU-kHHl09iXOmRIW-5lwXW&lt=43546193000009&hash=7a236ab8bdec69ae46c02a5142dfe0dc45bf03b30607c5f88fdf86daeb8e393b",
+    )
+    checkTripleResult(res, {
+      testnet: false,
+      lt: 43546193000009n,
+      hash: "7a236ab8bdec69ae46c02a5142dfe0dc45bf03b30607c5f88fdf86daeb8e393b",
+      address: "EQCVervJ0JDFlSdOsPos17zHdRBU-kHHl09iXOmRIW-5lwXW",
+    })
+  })
+
+  it("should parse testnet explorer.toncoin.org link", () => {
+    const res = extractTxInfoFromLink(
+      "https://test-explorer.toncoin.org/transaction?account=EQAkEiMt8S8Ur-umCyUn6YPXxpTzlSHH3T1vglKIFvuNObcl&lt=34542319000001&hash=041293cf00939d8df12badbdf6ab9e2091c8121941dbb170c543595403b5b97b",
+    )
+    checkTripleResult(res, {
+      testnet: true,
+      lt: 34542319000001n,
+      hash: "041293cf00939d8df12badbdf6ab9e2091c8121941dbb170c543595403b5b97b",
+      address: "EQAkEiMt8S8Ur-umCyUn6YPXxpTzlSHH3T1vglKIFvuNObcl",
+    })
+  })
+
+  it("shouldn't parse incorrect explorer.toncoin.org links", () => {
+    expect(() =>
+      extractTxInfoFromLink(
+        "https://test-explorer.toncoin.org/transaction?account=EQAkEiMt8S8Ur-umCyUn6YPXxpTzlSHH3T1vglKIFvuNl&lt=34542319000001&hash=041293cf00939d8df12badbdf6ab9e2091c8121941dbb170c543595403b5b97b",
+      ),
+    ).toThrow("Unknown address type: EQAkEiMt8S8Ur-umCyUn6YPXxpTzlSHH3T1vglKIFvuNl")
+  })
+
+  it("should parse explorer.toncoin.org link", () => {
+    const res = extractTxInfoFromLink(
+      "https://dton.io/tx/F64C6A3CDF3FAD1D786AACF9A6130F18F3F76EEB71294F53BBD812AD3703E70A",
+    )
+    checkHashResult(res, {
+      testnet: false,
+      hash: "f64c6a3cdf3fad1d786aacf9a6130f18f3f76eeb71294f53bbd812ad3703e70a",
+    })
+  })
+
+  it("should parse testnet explorer.toncoin.org link", () => {
+    const res = extractTxInfoFromLink(
+      "https://testnet.dton.io/tx/F64C6A3CDF3FAD1D786AACF9A6130F18F3F76EEB71294F53BBD812AD3703E70A",
+    )
+    checkHashResult(res, {
+      testnet: true,
+      hash: "f64c6a3cdf3fad1d786aacf9a6130f18f3f76eeb71294f53bbd812ad3703e70a",
+    })
+  })
+
+  function checkTripleResult(
+    res: ExtractionResult | undefined,
+    expected: {
+      testnet: boolean
+      lt: bigint
+      hash: string
+      address: string
+    },
+  ) {
+    expect(res).toBeDefined()
+    if (res?.$ !== "BaseInfo") {
+      expect(false).toBe(true)
+      return
+    }
+    const info = res.info
+    expect(res.testnet).toBe(expected.testnet)
+    expect(info.lt).toBe(expected.lt)
+    expect(info.hash.toString("base64")).toBe(expected.hash)
+    expect(info.address.toString()).toBe(expected.address)
+  }
+
+  function checkHashResult(
+    res: ExtractionResult | undefined,
+    expected: {
+      testnet: boolean
+      hash: string
+    },
+  ) {
+    expect(res).toBeDefined()
+    if (res?.$ !== "SingleHash") {
+      expect(false).toBe(true)
+      return
+    }
+    expect(res.testnet).toBe(expected.testnet)
+    expect(res.hash).toBe(expected.hash)
+  }
+})

--- a/src/features/txTrace/lib/links.ts
+++ b/src/features/txTrace/lib/links.ts
@@ -1,0 +1,115 @@
+import type {BaseTxInfo} from "@tonstudio/txtracer-core"
+import {Address} from "@ton/core"
+
+export type ExtractionResult = BaseInfo | SingleHash
+
+export type BaseInfo = {
+  $: "BaseInfo"
+  info: BaseTxInfo
+  testnet: boolean
+}
+
+export const BaseInfo = (info: BaseTxInfo, testnet: boolean): BaseInfo => ({
+  $: "BaseInfo",
+  info,
+  testnet,
+})
+
+export type SingleHash = {
+  $: "SingleHash"
+  hash: string
+  testnet: boolean
+}
+export const SingleHash = (hash: string, testnet: boolean): SingleHash => ({
+  $: "SingleHash",
+  hash: hash.toLowerCase(),
+  testnet,
+})
+
+/**
+ * Extracts transaction data from a URL pointing to one of the supported TON block explorers.
+ *
+ * Supported URL formats:
+ * - `https://ton.cx/tx/...` and `https://testnet.ton.cx/tx/...`
+ * - `https://tonviewer.com/transaction/...` and `https://testnet.tonviewer.com/transaction/...`
+ * - `https://tonscan.org/tx/...` and `https://testnet.tonscan.org/tx/...`
+ * - `https://explorer.toncoin.org/transaction?...` and `https://test-explorer.toncoin.org/transaction?...`
+ * - `https://dton.io/tx/...` and `https://testnet.dton.io/tx/...`
+ *
+ * Based on the domain, determines whether the link refers to mainnet or testnet,
+ * parses the relevant parameters (`lt`, `hash`, `address`), and returns:
+ * - `BaseInfo` — when `lt`, `hash`, and `address` are available;
+ * - `SingleHash` — when only `hash` is available.
+ *
+ * For unsupported URLs, returns `undefined`.
+ *
+ * @param txLink – A transaction URL.
+ * @returns An `ExtractionResult`, or `undefined` if the URL format is unrecognized.
+ * @throws Error if a link contains malformed data.
+ */
+export function extractTxInfoFromLink(txLink: string): ExtractionResult | undefined {
+  if (txLink.startsWith("https://ton.cx/tx/") || txLink.startsWith("https://testnet.ton.cx/tx/")) {
+    // https://ton.cx/tx/56166043000001:T6Y6ZoW71mrznFA0RyU/xV5ILpz9WUPJ9i9/4xPq1Is=:EQCqKZrrce8Ss6SZaLI-OkH2w8-xtPP9_ZvyyIZLhy9Hmpf8
+    const testnet = txLink.includes("testnet.")
+    const data = testnet ? txLink.slice(26) : txLink.slice(18)
+    const [lt, hash, address] = data.split(":")
+    return BaseInfo(fromTriple(lt, hash, address), testnet)
+  }
+
+  if (
+    txLink.startsWith("https://tonviewer.com/") ||
+    txLink.startsWith("https://testnet.tonviewer.com/")
+  ) {
+    // https://tonviewer.com/transaction/7a236ab8bdec69ae46c02a5142dfe0dc45bf03b30607c5f88fdf86daeb8e393b
+    const testnet = txLink.includes("testnet.")
+    const hash = testnet ? txLink.slice(42) : txLink.slice(34)
+    return SingleHash(hash, testnet)
+  }
+
+  if (
+    txLink.startsWith("https://tonscan.org/tx/") ||
+    txLink.startsWith("https://testnet.tonscan.org/tx/")
+  ) {
+    // https://tonscan.org/tx/7a236ab8bdec69ae46c02a5142dfe0dc45bf03b30607c5f88fdf86daeb8e393b
+    const testnet = txLink.includes("testnet.")
+    const hashMaybeBase64 = testnet ? txLink.slice(31) : txLink.slice(23)
+    if (hashMaybeBase64.endsWith("=")) {
+      const hash = Buffer.from(hashMaybeBase64, "base64")
+      return SingleHash(hash.toString("hex"), testnet)
+    }
+    return SingleHash(hashMaybeBase64, testnet)
+  }
+
+  if (
+    txLink.startsWith("https://explorer.toncoin.org/transaction") ||
+    txLink.startsWith("https://test-explorer.toncoin.org/transaction")
+  ) {
+    // https://explorer.toncoin.org/transaction?account=EQDa4VOnTYlLvDJ0gZjNYm5PXfSmmtL6Vs6A_CZEtXCNICq_&lt=47670702000009&hash=3e5f49798de239da5d8f80b4dc300204d37613e4203a3f7b877c04a88c81856b
+    const testnet = txLink.includes("test-")
+    const url = new URL(txLink)
+    const lt = url.searchParams.get("lt") ?? undefined
+    const hash = url.searchParams.get("hash") ?? undefined
+    const address = url.searchParams.get("account") ?? undefined
+    return BaseInfo(fromTriple(lt, hash, address), testnet)
+  }
+
+  if (txLink.startsWith("https://dton.io/tx") || txLink.startsWith("https://testnet.dton.io/tx")) {
+    // https://dton.io/tx/F64C6A3CDF3FAD1D786AACF9A6130F18F3F76EEB71294F53BBD812AD3703E70A
+    const testnet = txLink.includes("testnet.")
+    const infoPart = testnet ? txLink.slice(27) : txLink.slice(19)
+    return SingleHash(infoPart, testnet)
+  }
+
+  return undefined
+}
+
+function fromTriple(lt: string | undefined, hash: string | undefined, address: string | undefined) {
+  if (lt === undefined || hash === undefined || address === undefined) {
+    throw new Error("Invalid ton.cx link")
+  }
+  return {
+    lt: BigInt(lt),
+    hash: Buffer.from(hash, "base64"),
+    address: Address.parse(address),
+  }
+}

--- a/src/features/txTrace/lib/links.ts
+++ b/src/features/txTrace/lib/links.ts
@@ -96,8 +96,8 @@ export function extractTxInfoFromLink(txLink: string): ExtractionResult | undefi
   if (txLink.startsWith("https://dton.io/tx") || txLink.startsWith("https://testnet.dton.io/tx")) {
     // https://dton.io/tx/F64C6A3CDF3FAD1D786AACF9A6130F18F3F76EEB71294F53BBD812AD3703E70A
     const testnet = txLink.includes("testnet.")
-    const infoPart = testnet ? txLink.slice(27) : txLink.slice(19)
-    return SingleHash(infoPart, testnet)
+    const hash = testnet ? txLink.slice(27) : txLink.slice(19)
+    return SingleHash(hash, testnet)
   }
 
   return undefined

--- a/src/features/txTrace/lib/links.ts
+++ b/src/features/txTrace/lib/links.ts
@@ -4,9 +4,9 @@ import {Address} from "@ton/core"
 export type ExtractionResult = BaseInfo | SingleHash
 
 export type BaseInfo = {
-  $: "BaseInfo"
-  info: BaseTxInfo
-  testnet: boolean
+  readonly $: "BaseInfo"
+  readonly info: BaseTxInfo
+  readonly testnet: boolean
 }
 
 export const BaseInfo = (info: BaseTxInfo, testnet: boolean): BaseInfo => ({
@@ -16,9 +16,9 @@ export const BaseInfo = (info: BaseTxInfo, testnet: boolean): BaseInfo => ({
 })
 
 export type SingleHash = {
-  $: "SingleHash"
-  hash: string
-  testnet: boolean
+  readonly $: "SingleHash"
+  readonly hash: string
+  readonly testnet: boolean
 }
 export const SingleHash = (hash: string, testnet: boolean): SingleHash => ({
   $: "SingleHash",

--- a/src/features/txTrace/lib/links.ts
+++ b/src/features/txTrace/lib/links.ts
@@ -8,7 +8,6 @@ export type BaseInfo = {
   readonly info: BaseTxInfo
   readonly testnet: boolean
 }
-
 export const BaseInfo = (info: BaseTxInfo, testnet: boolean): BaseInfo => ({
   $: "BaseInfo",
   info,

--- a/src/features/txTrace/ui/StepInstructionBlock.tsx
+++ b/src/features/txTrace/ui/StepInstructionBlock.tsx
@@ -61,11 +61,7 @@ export const StepInstructionsList: React.FC<StepInstructionsListProps> = ({steps
   return (
     <>
       {steps.map((instruction, index) => (
-        <div
-          key={index}
-          className={styles.instructionItem}
-          style={{height: `${itemHeight}px`}}
-        >
+        <div key={index} className={styles.instructionItem} style={{height: `${itemHeight}px`}}>
           <span className={styles.instructionName}>{instruction.name}</span>
           <span className={styles.instructionGas}>{instruction.gasCost.toString()} gas</span>
         </div>


### PR DESCRIPTION
Supported URL formats:
- `https://ton.cx/tx/...` and `https://testnet.ton.cx/tx/...`
- `https://tonviewer.com/transaction/...` and `https://testnet.tonviewer.com/transaction/...`
- `https://tonscan.org/tx/...` and `https://testnet.tonscan.org/tx/...`
- `https://explorer.toncoin.org/transaction?...` and `https://test-explorer.toncoin.org/transaction?...`
- `https://dton.io/tx/...` and `https://testnet.dton.io/tx/...`