### PR TITLE
test(e2e): add test cases for tracing from URL

### DIFF
--- a/e2e-tests/links.spec.ts
+++ b/e2e-tests/links.spec.ts
@@ -23,16 +23,20 @@ const DTON = "https://dton.io/tx/F64C6A3CDF3FAD1D786AACF9A6130F18F3F76EEB71294F5
 const DTON_TESTNET =
   "https://testnet.dton.io/tx/041293cf00939d8df12badbdf6ab9e2091c8121941dbb170c543595403b5b97b"
 
+async function clickTraceButton(page: Page) {
+  const traceButton = page.getByRole("button", {name: "Trace"})
+  await expect(traceButton).toBeVisible()
+  await expect(traceButton).toBeEnabled()
+  await traceButton.click()
+}
+
 async function startTracing(page: Page, link: string) {
   const searchInput = page.getByPlaceholder("Search by transaction hash or explorer link")
   await expect(searchInput).toBeVisible()
   await searchInput.fill(link)
   await expect(searchInput).toHaveValue(link)
 
-  const traceButton = page.getByRole("button", {name: "Trace"})
-  await expect(traceButton).toBeVisible()
-  await expect(traceButton).toBeEnabled()
-  await traceButton.click()
+  await clickTraceButton(page)
 }
 
 test.describe("TxTracer Viewers Links", () => {
@@ -54,6 +58,15 @@ test.describe("TxTracer Viewers Links", () => {
       await wait() // TODO: Remove that. Cause we have only 1 rps from toncenter without API key
       await page.goto("/")
       await startTracing(page, link)
+      await checkPageLoaded(page)
+    })
+  })
+
+  tracingCases.forEach(([name, link]) => {
+    test(`should successfully trace with '${name}' from url`, async ({page}) => {
+      await wait() // TODO: Remove that. Cause we have only 1 rps from toncenter without API key
+      await page.goto(`/?tx=${link}`)
+      await clickTraceButton(page)
       await checkPageLoaded(page)
     })
   })


### PR DESCRIPTION
- Related to issue https://github.com/tact-lang/TxTracer/issues/37 

We should check tracing directly from url