### PR TITLE
test(e2e): add playground page tests and utils

### DIFF
--- a/e2e-tests/fixtures/fixtures.ts
+++ b/e2e-tests/fixtures/fixtures.ts
@@ -1,0 +1,13 @@
+import {test as base} from "@playwright/test"
+import {PlaygroundPage} from "../pages/playground-page"
+
+type Fixtures = {
+  readonly playgroundPage: PlaygroundPage
+}
+
+export const test = base.extend<Fixtures>({
+  playgroundPage: async ({page}, use) => {
+    const playgroundPage = new PlaygroundPage(page)
+    await use(playgroundPage)
+  },
+})

--- a/e2e-tests/fixtures/fixtures.ts
+++ b/e2e-tests/fixtures/fixtures.ts
@@ -1,4 +1,5 @@
 import {test as base} from "@playwright/test"
+
 import {PlaygroundPage} from "../pages/playground-page"
 
 type Fixtures = {
@@ -6,8 +7,8 @@ type Fixtures = {
 }
 
 export const test = base.extend<Fixtures>({
-  playgroundPage: async ({page}, use) => {
+  playgroundPage: async ({page}, useFixture) => {
     const playgroundPage = new PlaygroundPage(page)
-    await use(playgroundPage)
+    await useFixture(playgroundPage)
   },
 })

--- a/e2e-tests/links.spec.ts
+++ b/e2e-tests/links.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect, Page} from "@playwright/test"
+import {test, expect, type Page} from "@playwright/test"
 
 const TON_CX =
   "https://ton.cx/tx/43546193000009:eiNquL3saa5GwCpRQt/g3EW/A7MGB8X4j9+G2uuOOTs=:EQCVervJ0JDFlSdOsPos17zHdRBU-kHHl09iXOmRIW-5lwXW"

--- a/e2e-tests/main-workflow.spec.ts
+++ b/e2e-tests/main-workflow.spec.ts
@@ -1,4 +1,5 @@
-import {test, expect, Page} from "@playwright/test"
+import {test, expect, type Page} from "@playwright/test"
+import {getGasInfo, getStepInfo} from "./utils"
 
 const VALID_TEST_HASH_PLACEHOLDER =
   "5c7d6c306ca8a6ada7716d02f63e18a5b6f91ab9851caef0d22bd26e97eff7e8"
@@ -45,24 +46,6 @@ test.describe("TxTracer Main Workflow", () => {
 })
 
 test.describe("TxTracer Stepping Logic", () => {
-  const getStepInfo = (text: string | null): {current: number; total: number} | null => {
-    if (!text) return null
-    const match = text.match(/Step (\d+) of (\d+)/)
-    if (match) {
-      return {current: parseInt(match[1], 10), total: parseInt(match[2], 10)}
-    }
-    return null
-  }
-
-  const getGasInfo = (text: string | null): number | null => {
-    if (!text) return null
-    const match = text.match(/Used gas: (\d+)/)
-    if (match) {
-      return parseInt(match[1], 10)
-    }
-    return null
-  }
-
   test("should correctly update navigation buttons, step and gas counters", async ({
     page,
   }: {

--- a/e2e-tests/main-workflow.spec.ts
+++ b/e2e-tests/main-workflow.spec.ts
@@ -1,4 +1,5 @@
 import {test, expect, type Page} from "@playwright/test"
+
 import {getGasInfo, getStepInfo} from "./utils"
 
 const VALID_TEST_HASH_PLACEHOLDER =

--- a/e2e-tests/pages/playground-page.ts
+++ b/e2e-tests/pages/playground-page.ts
@@ -3,10 +3,30 @@ import type {Locator, Page} from "@playwright/test"
 export class PlaygroundPage {
   private stepCounter: Locator
   private editor: Locator
+  private tooltip: Locator
+  private executeButton: Locator
+  private shareButton: Locator
+  private exitCodeBadge: Locator
 
   constructor(public readonly page: Page) {
     this.stepCounter = this.page.getByTestId("step-counter-info")
     this.editor = this.page.locator(".view-lines")
+    this.tooltip = this.page.locator(".monaco-hover-content").last()
+    this.executeButton = this.page.getByRole("button", {name: "Execute"})
+    this.shareButton = this.page.getByRole("button", {name: "Share"})
+    this.exitCodeBadge = this.page.getByTestId("status-badge")
+  }
+
+  async execute() {
+    await this.executeButton.click()
+  }
+
+  async share() {
+    await this.shareButton.click()
+  }
+
+  async getExitCodeBadgeText() {
+    return await this.exitCodeBadge.textContent()
   }
 
   async goto() {
@@ -37,7 +57,9 @@ export class PlaygroundPage {
   async typeInEditor(code: string) {
     await this.editor.click()
     await this.page.keyboard.type(code)
-    await this.page.keyboard.press("Escape") // Dismiss any suggestion popups
+    await new Promise(resolve => setTimeout(resolve, 250))
+    await this.page.keyboard.press("Escape")
+    await new Promise(resolve => setTimeout(resolve, 250))
   }
 
   async getEditorText() {
@@ -70,5 +92,13 @@ export class PlaygroundPage {
     return await this.page.evaluate(() => {
       return localStorage.getItem("tutorial-completed-playground-page") !== null
     })
+  }
+
+  getTooltip() {
+    return this.tooltip
+  }
+
+  async waitForExitCodeBadge() {
+    await this.exitCodeBadge.waitFor({state: "visible"})
   }
 }

--- a/e2e-tests/pages/playground-page.ts
+++ b/e2e-tests/pages/playground-page.ts
@@ -1,0 +1,74 @@
+import type {Locator, Page} from "@playwright/test"
+
+export class PlaygroundPage {
+  private stepCounter: Locator
+  private editor: Locator
+
+  constructor(public readonly page: Page) {
+    this.stepCounter = this.page.getByTestId("step-counter-info")
+    this.editor = this.page.locator(".view-lines")
+  }
+
+  async goto() {
+    await this.page.goto("/play/")
+  }
+
+  /**
+   * This provides an ability to skip tutorial
+   */
+  async skipTutorial() {
+    await this.page.addInitScript(() => {
+      localStorage.setItem("tutorial-completed-playground-page", "true")
+    })
+  }
+
+  async focusEditor() {
+    await this.editor.click()
+  }
+
+  async clearEditor() {
+    await this.editor.click()
+    await this.page.keyboard.press(`Control+A`)
+    await new Promise(resolve => setTimeout(resolve, 250))
+    await this.page.keyboard.press("Delete")
+    await new Promise(resolve => setTimeout(resolve, 250))
+  }
+
+  async typeInEditor(code: string) {
+    await this.editor.click()
+    await this.page.keyboard.type(code)
+    await this.page.keyboard.press("Escape") // Dismiss any suggestion popups
+  }
+
+  async getEditorText() {
+    const lines = await this.editor.allInnerTexts()
+    return lines.join("\n")
+  }
+
+  async getStepCounterText() {
+    return await this.stepCounter.textContent()
+  }
+
+  async getTutorialPopup() {
+    return this.page
+      .getByRole("heading", {name: "Welcome to Assembly Playground"})
+      .locator("..")
+      .locator("..")
+  }
+
+  async getTutorialText() {
+    return this.page.getByText("Welcome to Assembly Playground")
+  }
+
+  async getTutorialTotalSteps() {
+    const popup = await this.getTutorialPopup()
+    const stepText = await popup.locator("text=of").innerText()
+    return parseInt(stepText.match(/of (\d+)/)?.[1] || "0", 10)
+  }
+
+  async isTutorialCompletedInStorage() {
+    return await this.page.evaluate(() => {
+      return localStorage.getItem("tutorial-completed-playground-page") !== null
+    })
+  }
+}

--- a/e2e-tests/pages/playground-page.ts
+++ b/e2e-tests/pages/playground-page.ts
@@ -49,19 +49,19 @@ export class PlaygroundPage {
     return await this.stepCounter.textContent()
   }
 
-  async getTutorialPopup() {
+  getTutorialPopup() {
     return this.page
       .getByRole("heading", {name: "Welcome to Assembly Playground"})
       .locator("..")
       .locator("..")
   }
 
-  async getTutorialText() {
+  getTutorialText() {
     return this.page.getByText("Welcome to Assembly Playground")
   }
 
   async getTutorialTotalSteps() {
-    const popup = await this.getTutorialPopup()
+    const popup = this.getTutorialPopup()
     const stepText = await popup.locator("text=of").innerText()
     return parseInt(stepText.match(/of (\d+)/)?.[1] || "0", 10)
   }

--- a/e2e-tests/pages/playground-page.ts
+++ b/e2e-tests/pages/playground-page.ts
@@ -29,17 +29,14 @@ export class PlaygroundPage {
     return await this.exitCodeBadge.textContent()
   }
 
-  async goto() {
+  async goto(skipTutorial: boolean = false) {
+    if (skipTutorial) {
+      await this.page.addInitScript(() => {
+        localStorage.setItem("tutorial-completed-playground-page", "true")
+      })
+    }
     await this.page.goto("/play/")
-  }
-
-  /**
-   * This provides an ability to skip tutorial
-   */
-  async skipTutorial() {
-    await this.page.addInitScript(() => {
-      localStorage.setItem("tutorial-completed-playground-page", "true")
-    })
+    await this.page.waitForLoadState("networkidle")
   }
 
   async focusEditor() {

--- a/e2e-tests/playground.spec.ts
+++ b/e2e-tests/playground.spec.ts
@@ -1,0 +1,111 @@
+import {expect} from "@playwright/test"
+
+import {test} from "./fixtures/fixtures"
+import {generateRandomAsmCode} from "./utils"
+
+test.describe("TxTracer Playground", () => {
+  test("should open from main page", async ({page, playgroundPage}) => {
+    await playgroundPage.goto()
+    const playgroundCard = page.getByText("Assembly Playground")
+
+    await playgroundCard.click()
+    expect(page.url()).toContain("/play/")
+  })
+
+  test("should skip skip tutorial via arrow keys", async ({page, playgroundPage}) => {
+    await playgroundPage.goto()
+    const totalSteps = await playgroundPage.getTutorialTotalSteps()
+
+    for (let i = 0; i < totalSteps; i++) {
+      await page.keyboard.press("ArrowRight")
+      await page.waitForTimeout(200)
+    }
+
+    const tutorial = await playgroundPage.getTutorialText()
+    await expect(tutorial).not.toBeVisible()
+
+    const hasTutorialFlag = await playgroundPage.isTutorialCompletedInStorage()
+    expect(hasTutorialFlag).toBe(true)
+
+    await page.reload()
+    const tutorialAfterReload = await playgroundPage.getTutorialText()
+    await expect(tutorialAfterReload).not.toBeVisible()
+  })
+
+  test("should skip tutorial via Escape key", async ({page, playgroundPage}) => {
+    await playgroundPage.goto()
+
+    const tutorial = await playgroundPage.getTutorialText()
+    await expect(tutorial).toBeVisible()
+
+    await page.keyboard.press("Escape")
+    const tutorialAfterEscape = await playgroundPage.getTutorialText()
+    await expect(tutorialAfterEscape).not.toBeVisible()
+
+    const hasTutorialFlag = await playgroundPage.isTutorialCompletedInStorage()
+    expect(hasTutorialFlag).toBe(true)
+
+    await page.reload()
+    const tutorialAfterReload = await playgroundPage.getTutorialText()
+    await expect(tutorialAfterReload).not.toBeVisible()
+  })
+
+  test("should 'Execute' code via Ctrl+Enter", async ({page, playgroundPage}) => {
+    await playgroundPage.skipTutorial()
+    await playgroundPage.goto()
+    const stepCounterText = await playgroundPage.getStepCounterText()
+    expect(stepCounterText).toBe("Ready to execute")
+
+    await page.keyboard.press("Control+Enter")
+
+    const exitCodeBadge = page.getByText("Exit code: 0")
+    await expect(exitCodeBadge).toBeVisible()
+  })
+
+  test("should 'Execute' code via button", async ({page, playgroundPage}) => {
+    await playgroundPage.skipTutorial()
+    await playgroundPage.goto()
+    const stepCounterText = await playgroundPage.getStepCounterText()
+    expect(stepCounterText).toBe("Ready to execute")
+
+    const executeButton = page.getByRole("button", {name: "Execute"})
+    await executeButton.click()
+
+    const exitCodeBadge = page.getByText("Exit code: 0")
+    await expect(exitCodeBadge).toBeVisible()
+  })
+
+  test("should write some code, share it and open shared link", async ({page, playgroundPage}) => {
+    await playgroundPage.skipTutorial()
+    await playgroundPage.goto()
+    const randomAsmCode = generateRandomAsmCode()
+    await playgroundPage.clearEditor()
+
+    await playgroundPage.typeInEditor(randomAsmCode)
+    const codeBefore = await playgroundPage.getEditorText()
+    await page.getByRole("button", {name: "Share"}).click()
+    const sharedUrl = await page.evaluate(() => navigator.clipboard.readText())
+    await page.goto(sharedUrl)
+    await page.waitForTimeout(250)
+    const codeAfter = await playgroundPage.getEditorText()
+
+    expect(codeAfter.trim()).toBe(codeBefore.trim())
+  })
+
+  test("should show error on invalid ASM code", async ({page, playgroundPage}) => {
+    const INSTRUCTION = "INVALID"
+    await playgroundPage.skipTutorial()
+    await playgroundPage.goto()
+
+    await playgroundPage.clearEditor()
+    await playgroundPage.typeInEditor(INSTRUCTION)
+    const executeButton = page.getByRole("button", {name: "Execute"})
+    await executeButton.click()
+
+    const errorEl = page.getByTestId("error-banner-info")
+    const errorText = await errorEl.textContent()
+    expect(errorText).toContain(
+      `Failed to execute assembly code: playground.tasm:1: Unexpected instruction: ${INSTRUCTION}×`,
+    )
+  })
+})

--- a/e2e-tests/playground.spec.ts
+++ b/e2e-tests/playground.spec.ts
@@ -4,8 +4,8 @@ import {test} from "./fixtures/fixtures"
 import {generateRandomAsmCode} from "./utils"
 
 test.describe("TxTracer Playground", () => {
-  test("should open from main page", async ({page, playgroundPage}) => {
-    await playgroundPage.goto()
+  test("should open from main page", async ({page}) => {
+    await page.goto("/")
     const playgroundCard = page.getByText("Assembly Playground")
 
     await playgroundCard.click()
@@ -58,21 +58,20 @@ test.describe("TxTracer Playground", () => {
 
     await page.keyboard.press("Control+Enter")
 
-    const exitCodeBadge = page.getByText("Exit code: 0")
-    await expect(exitCodeBadge).toBeVisible()
+    const exitCodeBadgeText = await playgroundPage.getExitCodeBadgeText()
+    expect(exitCodeBadgeText).toBe("Exit code: 0")
   })
 
-  test("should 'Execute' code via button", async ({page, playgroundPage}) => {
+  test("should 'Execute' code via button", async ({playgroundPage}) => {
     await playgroundPage.skipTutorial()
     await playgroundPage.goto()
     const stepCounterText = await playgroundPage.getStepCounterText()
     expect(stepCounterText).toBe("Ready to execute")
 
-    const executeButton = page.getByRole("button", {name: "Execute"})
-    await executeButton.click()
+    await playgroundPage.execute()
 
-    const exitCodeBadge = page.getByText("Exit code: 0")
-    await expect(exitCodeBadge).toBeVisible()
+    const exitCodeBadgeText = await playgroundPage.getExitCodeBadgeText()
+    expect(exitCodeBadgeText).toBe("Exit code: 0")
   })
 
   test("should write some code, share it and open shared link", async ({page, playgroundPage}) => {
@@ -83,7 +82,7 @@ test.describe("TxTracer Playground", () => {
 
     await playgroundPage.typeInEditor(randomAsmCode)
     const codeBefore = await playgroundPage.getEditorText()
-    await page.getByRole("button", {name: "Share"}).click()
+    await playgroundPage.share()
     const sharedUrl = await page.evaluate(() => navigator.clipboard.readText())
     await page.goto(sharedUrl)
     await page.waitForTimeout(250)
@@ -99,13 +98,54 @@ test.describe("TxTracer Playground", () => {
 
     await playgroundPage.clearEditor()
     await playgroundPage.typeInEditor(INSTRUCTION)
-    const executeButton = page.getByRole("button", {name: "Execute"})
-    await executeButton.click()
+    await playgroundPage.execute()
 
     const errorEl = page.getByTestId("error-banner-info")
     const errorText = await errorEl.textContent()
     expect(errorText).toContain(
       `Failed to execute assembly code: playground.tasm:1: Unexpected instruction: ${INSTRUCTION}×`,
     )
+  })
+
+  test("should hover instruction before execution and get tooltip", async ({
+    page,
+    playgroundPage,
+  }) => {
+    const INSTRUCTION = "ADD"
+    await playgroundPage.skipTutorial()
+    await playgroundPage.goto()
+
+    await playgroundPage.clearEditor()
+    await playgroundPage.typeInEditor(INSTRUCTION)
+    const instruction = page.getByText(INSTRUCTION)
+    await instruction.hover()
+
+    await expect(playgroundPage.getTooltip()).toBeVisible()
+    const text = await playgroundPage.getTooltip().allInnerTexts()
+    expect(text).toHaveLength(1)
+    expect(text[0]).toContain(INSTRUCTION)
+    expect(text[0]).toContain("Not executed")
+  })
+
+  test("should hover instruction after execution and get tooltip", async ({
+    page,
+    playgroundPage,
+  }) => {
+    await playgroundPage.skipTutorial()
+    await playgroundPage.goto()
+
+    // Execute the code first
+    await playgroundPage.execute()
+    await playgroundPage.waitForExitCodeBadge()
+
+    // Now hover over the instruction
+    const instruction = page.getByText("PUSHINT_8 42")
+    await instruction.hover()
+
+    await expect(playgroundPage.getTooltip()).toBeVisible()
+    const text = await playgroundPage.getTooltip().allInnerTexts()
+    expect(text).toHaveLength(1)
+    expect(text[0]).toContain("PUSHINT_8")
+    expect(text[0]).toContain("Executions: 1")
   })
 })

--- a/e2e-tests/playground.spec.ts
+++ b/e2e-tests/playground.spec.ts
@@ -21,32 +21,32 @@ test.describe("TxTracer Playground", () => {
       await page.waitForTimeout(200)
     }
 
-    const tutorial = await playgroundPage.getTutorialText()
+    const tutorial = playgroundPage.getTutorialText()
     await expect(tutorial).not.toBeVisible()
 
     const hasTutorialFlag = await playgroundPage.isTutorialCompletedInStorage()
     expect(hasTutorialFlag).toBe(true)
 
     await page.reload()
-    const tutorialAfterReload = await playgroundPage.getTutorialText()
+    const tutorialAfterReload = playgroundPage.getTutorialText()
     await expect(tutorialAfterReload).not.toBeVisible()
   })
 
   test("should skip tutorial via Escape key", async ({page, playgroundPage}) => {
     await playgroundPage.goto()
 
-    const tutorial = await playgroundPage.getTutorialText()
+    const tutorial = playgroundPage.getTutorialText()
     await expect(tutorial).toBeVisible()
 
     await page.keyboard.press("Escape")
-    const tutorialAfterEscape = await playgroundPage.getTutorialText()
+    const tutorialAfterEscape = playgroundPage.getTutorialText()
     await expect(tutorialAfterEscape).not.toBeVisible()
 
     const hasTutorialFlag = await playgroundPage.isTutorialCompletedInStorage()
     expect(hasTutorialFlag).toBe(true)
 
     await page.reload()
-    const tutorialAfterReload = await playgroundPage.getTutorialText()
+    const tutorialAfterReload = playgroundPage.getTutorialText()
     await expect(tutorialAfterReload).not.toBeVisible()
   })
 

--- a/e2e-tests/playground.spec.ts
+++ b/e2e-tests/playground.spec.ts
@@ -51,8 +51,7 @@ test.describe("TxTracer Playground", () => {
   })
 
   test("should 'Execute' code via Ctrl+Enter", async ({page, playgroundPage}) => {
-    await playgroundPage.skipTutorial()
-    await playgroundPage.goto()
+    await playgroundPage.goto(true)
     const stepCounterText = await playgroundPage.getStepCounterText()
     expect(stepCounterText).toBe("Ready to execute")
 
@@ -63,8 +62,7 @@ test.describe("TxTracer Playground", () => {
   })
 
   test("should 'Execute' code via button", async ({playgroundPage}) => {
-    await playgroundPage.skipTutorial()
-    await playgroundPage.goto()
+    await playgroundPage.goto(true)
     const stepCounterText = await playgroundPage.getStepCounterText()
     expect(stepCounterText).toBe("Ready to execute")
 
@@ -75,8 +73,7 @@ test.describe("TxTracer Playground", () => {
   })
 
   test("should write some code, share it and open shared link", async ({page, playgroundPage}) => {
-    await playgroundPage.skipTutorial()
-    await playgroundPage.goto()
+    await playgroundPage.goto(true)
     const randomAsmCode = generateRandomAsmCode()
     await playgroundPage.clearEditor()
 
@@ -93,8 +90,7 @@ test.describe("TxTracer Playground", () => {
 
   test("should show error on invalid ASM code", async ({page, playgroundPage}) => {
     const INSTRUCTION = "INVALID"
-    await playgroundPage.skipTutorial()
-    await playgroundPage.goto()
+    await playgroundPage.goto(true)
 
     await playgroundPage.clearEditor()
     await playgroundPage.typeInEditor(INSTRUCTION)
@@ -112,8 +108,7 @@ test.describe("TxTracer Playground", () => {
     playgroundPage,
   }) => {
     const INSTRUCTION = "ADD"
-    await playgroundPage.skipTutorial()
-    await playgroundPage.goto()
+    await playgroundPage.goto(true)
 
     await playgroundPage.clearEditor()
     await playgroundPage.typeInEditor(INSTRUCTION)
@@ -131,8 +126,7 @@ test.describe("TxTracer Playground", () => {
     page,
     playgroundPage,
   }) => {
-    await playgroundPage.skipTutorial()
-    await playgroundPage.goto()
+    await playgroundPage.goto(true)
 
     // Execute the code first
     await playgroundPage.execute()

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -1,0 +1,110 @@
+import {type Page} from "@playwright/test"
+
+export const getStepInfo = (text: string | null): {current: number; total: number} | null => {
+  if (!text) return null
+  const match = text.match(/Step (\d+) of (\d+)/)
+  if (match) {
+    return {current: parseInt(match[1], 10), total: parseInt(match[2], 10)}
+  }
+  return null
+}
+
+export const getGasInfo = (text: string | null): number | null => {
+  if (!text) return null
+  const match = text.match(/Used gas: (\d+)/)
+  if (match) {
+    return parseInt(match[1], 10)
+  }
+  return null
+}
+
+export async function getStepCounterText(page: Page) {
+  return await page.getByTestId("step-counter-info").textContent()
+}
+
+/**
+ * Skip all available tutorials
+ * @param page
+ */
+export const skipTutorialsOnLoad = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("tutorial-completed-playground-page", "true")
+    localStorage.setItem("tutorial-completed-godbolt-page", "true")
+  })
+}
+
+export const focusEditor = async (page: Page) => {
+  const editor = page.locator(".view-lines")
+  await editor.click()
+}
+
+/**
+ * Clear editor from all text content
+ * @param page
+ */
+export const clearEditor = async (page: Page) => {
+  const editor = page.locator(".view-lines")
+  await editor.click()
+  const modifier = process.platform === "darwin" ? "Meta" : "Control"
+  await page.keyboard.press(`${modifier}+A`)
+  await page.keyboard.press("Delete")
+}
+
+/**
+ * Write code in editor
+ * @param page
+ * @param code
+ */
+export const typeInEditor = async (page: Page, code: string) => {
+  const editor = page.locator(".view-lines")
+  await editor.click()
+  await page.keyboard.type(code)
+  await page.keyboard.press("Escape") // Dismiss any suggestion popups
+}
+
+export const getEditorText = async (page: Page) => {
+  const editor = page.locator(".view-lines")
+  const lines = await editor.allInnerTexts()
+  return lines.join("\n")
+}
+
+export const pressCommandOnEditor = async (page: Page) => {
+  const modifier = process.platform === "darwin" ? "Meta" : "Control"
+  await page.keyboard.down(modifier)
+}
+
+export const getAvailableToClickLines = async (page: Page) => {
+  return await page.$$eval(".clickable-line-decoration", decorations => {
+    return decorations
+      .map(dec => {
+        const lineNumberEl = dec.parentElement?.querySelector(".line-numbers")
+        return lineNumberEl?.textContent?.trim()
+      })
+      .filter((n): n is string => !!n)
+  })
+}
+
+export const clickLine = async (page: Page, line: number) => {
+  const el = page.locator(`(//div[contains(@class, "view-lines")])[1]/*[${line}]`)
+  return await el.click()
+}
+
+export const getLineContent = async (page: Page, line: number) => {
+  const el = page.locator(`(//div[contains(@class, "view-lines")])[1]/*[${line}]`)
+  return await el.textContent()
+}
+
+export const generateRandomAsmCode = () => {
+  const instructions = ["SETCP 0", "SWAP", "DROP", "NOP", "CTOS", "POP s3"]
+  const lines: string[] = []
+  const count = Math.floor(Math.random() * 4) + 2 // generate 2–5 lines
+  for (let i = 0; i < count; i++) {
+    const line = instructions[Math.floor(Math.random() * instructions.length)]
+    lines.push(line)
+  }
+  return lines.join("\n")
+}
+
+export const wait = async (delay: number) => {
+  return new Promise(resolve => setTimeout(resolve, delay))
+}

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -18,38 +18,6 @@ export const getGasInfo = (text: string | null): number | null => {
   return null
 }
 
-export async function getStepCounterText(page: Page) {
-  return await page.getByTestId("step-counter-info").textContent()
-}
-
-/**
- * Skip all available tutorials
- * @param page
- */
-export const skipTutorialsOnLoad = async (page: Page) => {
-  await page.addInitScript(() => {
-    localStorage.setItem("tutorial-completed-playground-page", "true")
-    localStorage.setItem("tutorial-completed-godbolt-page", "true")
-  })
-}
-
-export const focusEditor = async (page: Page) => {
-  const editor = page.locator(".view-lines")
-  await editor.click()
-}
-
-/**
- * Clear editor from all text content
- * @param page
- */
-export const clearEditor = async (page: Page) => {
-  const editor = page.locator(".view-lines")
-  await editor.click()
-  const modifier = process.platform === "darwin" ? "Meta" : "Control"
-  await page.keyboard.press(`${modifier}+A`)
-  await page.keyboard.press("Delete")
-}
-
 /**
  * Write code in editor
  * @param page

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -97,5 +97,16 @@ export default tseslint.config(
       },
     },
   },
+  {
+    files: ["e2e-tests/**/*.{ts,js}"],
+    rules: {
+      "react-hooks/rules-of-hooks": "off",
+      "react-hooks/exhaustive-deps": "off",
+      "react/prop-types": "off",
+      "react/react-in-jsx-scope": "off",
+      "react/jsx-uses-react": "off",
+      "react/jsx-uses-vars": "off",
+    },
+  },
   eslintConfigPrettier,
 )

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,7 @@ export default tseslint.config(
       "src/features/godbolt/lib/func/func-wasm/func-compile.ts",
       "src/features/godbolt/lib/func/func-wasm/funcfiftlib.d.ts",
       ".test-project/",
+      ".yarn",
     ],
   },
   {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: "http://localhost:5174/",
-
+    permissions: ["clipboard-read"],
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on",
     screenshot: "only-on-failure",

--- a/src/shared/ui/ErrorBanner/ErrorBanner.tsx
+++ b/src/shared/ui/ErrorBanner/ErrorBanner.tsx
@@ -34,6 +34,7 @@ const ErrorBanner: React.FC<Props> = ({message, onClose}) => {
       role="alert"
       aria-live="assertive"
       aria-atomic="true"
+      data-testid="error-banner-info"
     >
       <span>{message}</span>
       <Button

--- a/src/shared/ui/StatusBadge/StatusBadge.tsx
+++ b/src/shared/ui/StatusBadge/StatusBadge.tsx
@@ -26,7 +26,12 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({type, text}) => {
 
   if (type === "success") {
     return (
-      <span className={styles.statusSuccess} role="status" aria-label={getAriaLabel()}>
+      <span
+        className={styles.statusSuccess}
+        role="status"
+        aria-label={getAriaLabel()}
+        data-testid="status-badge"
+      >
         <svg
           width="16"
           height="16"
@@ -55,7 +60,12 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({type, text}) => {
     )
   } else if (type === "failed") {
     return (
-      <span className={styles.statusFailed} role="status" aria-label={getAriaLabel()}>
+      <span
+        className={styles.statusFailed}
+        role="status"
+        aria-label={getAriaLabel()}
+        data-testid="status-badge"
+      >
         <svg
           width="16"
           height="16"
@@ -91,7 +101,12 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({type, text}) => {
     )
   } else if (type === "warning") {
     return (
-      <span className={styles.statusWarning} role="status" aria-label={getAriaLabel()}>
+      <span
+        className={styles.statusWarning}
+        role="status"
+        aria-label={getAriaLabel()}
+        data-testid="status-badge"
+      >
         <svg
           width="16"
           height="16"


### PR DESCRIPTION
Issue #54 

- Add new test files for playground functionality
- Extract utility functions into separate utils module
- Add test fixtures for page objects
- Update eslint config to ignore .yarn directory
- Add clipboard permission to playwright config
- Add testid to ErrorBanner component

