### PR TITLE
fix: separate `yarn test` and `yarn test:e2e`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,6 +63,8 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["src/setupTests.ts"],
+    include: ["src/**/*.spec.ts", "src/**/*.test.ts"],
+    exclude: ["e2e-tests/**"],
     // coverage: {
     //   reporter: ["text", "json", "html"],
     //   provider: "v8", // or "istanbul"


### PR DESCRIPTION
## Summary

- Updated the Vitest configuration to specify which test files to include and to exclude e2e specs and dependencies